### PR TITLE
API: Add delete_records endpoint

### DIFF
--- a/gristapi/gristapi_test.go
+++ b/gristapi/gristapi_test.go
@@ -407,4 +407,3 @@ func TestDeleteRecords(t *testing.T) {
 		t.Errorf("Expected status 200, got %d", status)
 	}
 }
-


### PR DESCRIPTION
## Summary
- Adds `DELETE /docs/{docId}/tables/{tableId}/records/delete` API endpoint
- Adds `delete_records` MCP tool for AI agent integration
- Enhances TUI with table actions, document access view, and delete confirmation

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added delete_records tool to remove records from documents using document ID, table ID, and row IDs as parameters.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->